### PR TITLE
Update org.jetbrains.intellij

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
-    id("org.jetbrains.intellij") version "1.8.0"
+    id("org.jetbrains.intellij") version "1.13.3"
 }
 
 group = "io.github.riej"


### PR DESCRIPTION
I had problems running the project with the old `org.jetbrains.intellij` version before. Now I don't anymore (and I forgot what the error was), but there's still this reason to update it:
> Gradle IntelliJ Plugin is outdated: 1.8.0. Update `org.jetbrains.intellij` to: 1.13.3

The plugin works with both versions, as far as I've tested it.