### PR TITLE
[Fix #6] Fix the refreshing of the argument list

### DIFF
--- a/src/main/kotlin/io/github/riej/lsl/psi/LslArguments.kt
+++ b/src/main/kotlin/io/github/riej/lsl/psi/LslArguments.kt
@@ -2,26 +2,13 @@ package io.github.riej.lsl.psi
 
 import com.intellij.extapi.psi.ASTWrapperPsiElement
 import com.intellij.lang.ASTNode
-import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.psi.text.BlockSupport
-import com.intellij.refactoring.suggested.endOffset
-import com.intellij.refactoring.suggested.startOffset
-import com.intellij.util.FileContentUtil
-import com.intellij.util.FileContentUtilCore
 import io.github.riej.lsl.parser.LslTypes
 
 class LslArguments(node: ASTNode) : ASTWrapperPsiElement(node) {
-    val arguments: List<LslArgument> = findChildrenByType(LslTypes.ARGUMENT)
+    var arguments: List<LslArgument> = findChildrenByType(LslTypes.ARGUMENT)
+        private set
 
     override fun subtreeChanged() {
-        // There is problem when modification of function arguments doesn't affects to function body.
-        // For example:
-        // integer meow() { return a + b; }
-        // IDE will show errors at `a` and `b` - because they does not exists yet.
-        // But if you write arguments (`integer a, integer b`), IDE still will show errors.
-        // I really have no idea how to fix this behavior except reparsing whole file.
-        // This is slow, but it works.
-        // TODO: find proper solution.
-        FileContentUtilCore.reparseFiles(this.containingFile.virtualFile)
+        arguments = findChildrenByType(LslTypes.ARGUMENT)
     }
 }


### PR DESCRIPTION
I've made sure that:
1. When I remove the `reparseFiles` workaround, the bug described in the TODO really does occur
2. Setting `arguments` to a new value fixes the bug just as well as the workaround does
3. Issue #6 doesn't occur with the new code. It's intermittent, so who knows really, but the new code is simpler and faster anyway.

This fixes #6 (hopefully)